### PR TITLE
fixed filters for pixi v3, with es6 support

### DIFF
--- a/src/BlueInvertFilter.js
+++ b/src/BlueInvertFilter.js
@@ -1,35 +1,20 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
-
-PIXI_GLITCH.BlueInvertFilter = function () {
-    PIXI.AbstractFilter.call(this);
-
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(0.2,0.2,0.4);',
-        '   vec3 min = vec3(0.0,0.0,1.0);',
-        '   vec3 max = vec3(1.0,1.0,0.0);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+function BlueInvertFilter() {
+    PIXI.AbstractFilter.call(this,
+    
+    null,
+      
+    fs.readFileSync(__dirname + '/blueinvert.frag', 'utf8'));
 
 };
 
-PIXI_GLITCH.BlueInvertFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.BlueInvertFilter.prototype.constructor = PIXI_GLITCH.BlueRaiseFilter;
+BlueInvertFilter.prototype = Object.create(core.AbstractFilter.prototype);
+BlueInvertFilter.prototype.constructor = core.BlueRaiseFilter;
 
-
+module.exports = BlueInvertFilter;

--- a/src/BlueRaiseFilter.js
+++ b/src/BlueRaiseFilter.js
@@ -1,35 +1,19 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function BlueRaiseFilter() {
+    PIXI.AbstractFilter.call(this,
 
-PIXI_GLITCH.BlueRaiseFilter = function () {
-    PIXI.AbstractFilter.call(this);
+    null,
 
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(0.2,0.2,.25);',
-        '   vec3 min = vec3(0.0,0.0,0.2);',
-        '   vec3 max = vec3(1.0,1.0,0.8);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
-
+    fs.readFileSync(__dirname + '/blueraise.frag', 'utf8'));
 };
 
-PIXI_GLITCH.BlueRaiseFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.BlueRaiseFilter.prototype.constructor = PIXI_GLITCH.BlueRaiseFilter;
+BlueRaiseFilter.prototype = Object.create(core.AbstractFilter.prototype);
+BlueRaiseFilter.prototype.constructor = BlueRaiseFilter;
 
-
+module.exports = BlueRaiseFilter;

--- a/src/ConvergenceFilter.js
+++ b/src/ConvergenceFilter.js
@@ -1,45 +1,29 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function ConvergenceFilter() {
 
-PIXI_GLITCH.ConvergenceFilter = function () {
+    PIXI.AbstractFilter.call(this,
 
-    PIXI.AbstractFilter.call(this);
+      null,
 
-    this.passes = [this];
+      fs.readFileSync(__dirname + '/convergence.frag', 'utf8'),
 
-    this.uniforms = {
+      {
         rand: {type: '1f', value: 0.5},
         dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform float rand;',
-        'uniform vec4 dimensions;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec4 col_r = texture2D(uSampler, vTextureCoord + vec2((-35.0 / dimensions.x) * rand, 0));',
-        '   vec4 col_l = texture2D(uSampler, vTextureCoord + vec2((35.0 / dimensions.x) * rand, 0));',
-        '   vec4 col_g = texture2D(uSampler, vTextureCoord + vec2((-7.5 / dimensions.x) * rand, 0));',
-        '   col.r = col.r + col_l.r * max(1.0, sin(vTextureCoord.y * dimensions.y * 1.2) * 2.5) * rand;',
-        '   col.b = col.b + col_r.b * max(1.0, sin(vTextureCoord.y * dimensions.y * 1.2) * 2.5) * rand;',
-        '   col.g = col.g + col_g.g * max(1.0, sin(vTextureCoord.y * dimensions.y * 1.2) * 2.5) * rand;',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
-
+      }
+    );
 };
 
-PIXI_GLITCH.ConvergenceFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.ConvergenceFilter.prototype.constructor = PIXI_GLITCH.ConvergenceFilter;
+ConvergenceFilter.prototype = Object.create(core.AbstractFilter.prototype);
+ConvergenceFilter.prototype.constructor = ConvergenceFilter;
 
-Object.defineProperty(PIXI_GLITCH.ConvergenceFilter.prototype, 'rand', {
+Object.defineProperty(ConvergenceFilter.prototype, 'rand', {
     get: function() {
         return this.uniforms.rand.value;
     },
@@ -48,3 +32,5 @@ Object.defineProperty(PIXI_GLITCH.ConvergenceFilter.prototype, 'rand', {
         this.uniforms.rand.value = value;
     }
 });
+
+module.exports = ConvergenceFilter;

--- a/src/CutSliderFilter.js
+++ b/src/CutSliderFilter.js
@@ -1,45 +1,31 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function CutSliderFilter() {
+    PIXI.AbstractFilter.call(this,
+      
+      null,
 
-PIXI_GLITCH.CutSliderFilter = function () {
-    PIXI.AbstractFilter.call(this);
+      fs.readFileSync(__dirname + '/cutslider.frag', 'utf8'),
 
-    this.passes = [this];
 
-    this.uniforms = {
-        rand: {type: '1f', value: 5},
-        val1: {type: '1f', value: 150},
-        val2: {type: '1f', value: 20},
-        dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'uniform float rand;',
-        'uniform float val1;',
-        'uniform float val2;',
-        'uniform vec4 dimensions;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec2 posOffset = pos + vec2(floor(sin(pos.y / val1 * rand + rand * rand)) * val2 * rand, 0);',
-        '   posOffset = posOffset / vec2(dimensions);',
-        '   vec4 col = texture2D(uSampler, posOffset);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
-
+      {
+          rand: {type: '1f', value: 5},
+          val1: {type: '1f', value: 150},
+          val2: {type: '1f', value: 20},
+          dimensions: {type: '4fv', value: [0, 0, 0, 0]}
+      }
+    );
 };
 
-PIXI_GLITCH.CutSliderFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.CutSliderFilter.prototype.constructor = PIXI_GLITCH.CutSliderFilter;
+CutSliderFilter.prototype = Object.create(core.AbstractFilter.prototype);
+CutSliderFilter.prototype.constructor = CutSliderFilter;
 
-Object.defineProperty(PIXI_GLITCH.CutSliderFilter.prototype, 'rand', {
+Object.defineProperty(CutSliderFilter.prototype, 'rand', {
     get: function() {
         return this.uniforms.rand.value;
     },
@@ -49,7 +35,7 @@ Object.defineProperty(PIXI_GLITCH.CutSliderFilter.prototype, 'rand', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.CutSliderFilter.prototype, 'val1', {
+Object.defineProperty(CutSliderFilter.prototype, 'val1', {
     get: function() {
         return this.uniforms.val1.value;
     },
@@ -59,7 +45,7 @@ Object.defineProperty(PIXI_GLITCH.CutSliderFilter.prototype, 'val1', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.CutSliderFilter.prototype, 'val2', {
+Object.defineProperty(CutSliderFilter.prototype, 'val2', {
     get: function() {
         return this.uniforms.val2.value;
     },
@@ -68,3 +54,5 @@ Object.defineProperty(PIXI_GLITCH.CutSliderFilter.prototype, 'val2', {
         this.uniforms.val2.value = value;
     }
 });
+
+module.exports = CutSliderFilter;

--- a/src/GlowFilter.js
+++ b/src/GlowFilter.js
@@ -1,56 +1,29 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function GlowFilter() {
+    PIXI.AbstractFilter.call(this,
 
-PIXI_GLITCH.GlowFilter = function () {
-    PIXI.AbstractFilter.call(this);
+      null,
 
-    this.passes = [this];
+      fs.readFileSync(__dirname + '/glow.frag', 'utf8'),
 
-    this.uniforms = {
+    {
         blur_w: {type: '1i', value: 8},
         dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform vec4 dimensions;',
-        'uniform sampler2D uSampler;',
-        'uniform int blur_w;',
-        'varying vec2 vTextureCoord;',
-        'const float strength = 1.3;',
-        'void main (void)',
-        '{',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec4 gws = vec4(0.0, 0.0, 0.0, 1.0);',
-        '   float weight = 1.0 / (float(blur_w) * 2.0 + 1.0) / (float(blur_w) * 2.0 + 1.0);',
-        '   for (int i = 0; i < 1024; i++) {',
-        '       if (i > blur_w * blur_w) {break;}',
-        '       float miw = float(mod(float(i), float(blur_w)));',
-        '       float idw = float(i / blur_w);',
-        '       vec2 v1 = vec2(pos.x + miw, pos.y + idw);',
-        '       vec2 v2 = vec2(pos.x - miw, pos.y + idw);',
-        '       vec2 v3 = vec2(pos.x + miw, pos.y - idw);',
-        '       vec2 v4 = vec2(pos.x - miw, pos.y - idw);',
-        '       gws = gws + texture2D(uSampler, v1 / vec2(dimensions)) * weight * strength;',
-        '       gws = gws + texture2D(uSampler, v2 / vec2(dimensions)) * weight * strength;',
-        '       gws = gws + texture2D(uSampler, v3 / vec2(dimensions)) * weight * strength;',
-        '       gws = gws + texture2D(uSampler, v4 / vec2(dimensions)) * weight * strength;',
-        '   }',
-        '   gl_FragColor.rgba = col + gws;',
-        '}'
-    ];
-
+    }
+  );
 };
 
-PIXI_GLITCH.GlowFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.GlowFilter.prototype.constructor = PIXI_GLITCH.GlowFilter;
+GlowFilter.prototype = Object.create(core.AbstractFilter.prototype);
+GlowFilter.prototype.constructor = GlowFilter;
 
 
-Object.defineProperty(PIXI_GLITCH.GlowFilter.prototype, 'blur', {
+Object.defineProperty(GlowFilter.prototype, 'blur', {
     get: function() {
         return this.uniforms.blur_w.value;
     },
@@ -59,3 +32,5 @@ Object.defineProperty(PIXI_GLITCH.GlowFilter.prototype, 'blur', {
         this.uniforms.blur_w.value = Math.floor(value);
     }
 });
+
+module.exports = GlowFilter;

--- a/src/GreenInvertFilter.js
+++ b/src/GreenInvertFilter.js
@@ -1,35 +1,20 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function GreenInvertFilter() {
+    PIXI.AbstractFilter.call(this,
 
-PIXI_GLITCH.GreenInvertFilter = function () {
-    PIXI.AbstractFilter.call(this);
+    null,
 
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(0.2,0.4,0.2);',
-        '   vec3 min = vec3(0.0,1.0,0.0);',
-        '   vec3 max = vec3(1.0,0.8,1.0);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+    fs.readFileSync(__dirname + '/greeninvert.frag', 'utf8'));
 
 };
 
-PIXI_GLITCH.GreenInvertFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.GreenInvertFilter.prototype.constructor = PIXI_GLITCH.GreenInvertFilter;
+GreenInvertFilter.prototype = Object.create(core.AbstractFilter.prototype);
+GreenInvertFilter.prototype.constructor = GreenInvertFilter;
 
-
+module.exports = GreenInvertFilter;

--- a/src/GreenRaiseFilter.js
+++ b/src/GreenRaiseFilter.js
@@ -1,35 +1,20 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function GreenRaiseFilter() {
+    PIXI.AbstractFilter.call(this,
 
-PIXI_GLITCH.GreenRaiseFilter = function () {
-    PIXI.AbstractFilter.call(this);
+    null,
 
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(0.2,.25,0.2);',
-        '   vec3 min = vec3(0.0,0.2,0.0);',
-        '   vec3 max = vec3(1.0,0.8,1.0);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+    fs.readFileSync(__dirname + '/greenraise.frag', 'utf8'));
 
 };
 
-PIXI_GLITCH.GreenRaiseFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.GreenRaiseFilter.prototype.constructor = PIXI_GLITCH.GreenRaiseFilter;
+GreenRaiseFilter.prototype = Object.create(core.AbstractFilter.prototype);
+GreenRaiseFilter.prototype.constructor = GreenRaiseFilter;
 
-
+module.exports = GreenRaiseFilter;

--- a/src/HighContrastFilter.js
+++ b/src/HighContrastFilter.js
@@ -1,35 +1,20 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function HighContrastFilter() {
+    PIXI.AbstractFilter.call(this,
 
-PIXI_GLITCH.HighContrastFilter = function () {
-    PIXI.AbstractFilter.call(this);
+    null,
 
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(0.8,0.8,0.8);',
-        '   vec3 min = vec3(0.0,0.0,0.0);',
-        '   vec3 max = vec3(1.0,1.0,1.0);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+      fs.readFileSync(__dirname + '/highcontrast.frag', 'utf8'));
 
 };
 
-PIXI_GLITCH.HighContrastFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.HighContrastFilter.prototype.constructor = PIXI_GLITCH.HighContrastFilter;
+HighContrastFilter.prototype = Object.create(core.AbstractFilter.prototype);
+HighContrastFilter.prototype.constructor = HighContrastFilter;
 
-
+module.exports = HighContrastFilter;

--- a/src/InvertFilter.js
+++ b/src/InvertFilter.js
@@ -1,34 +1,21 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function InvertFilter() {
+    core.AbstractFilter.call(this,
+    
+    null,
 
-PIXI_GLITCH.InvertFilter = function () {
-    PIXI.AbstractFilter.call(this);
-
-    this.passes = [this];
-
-    this.uniforms = {
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'uniform bool enabled;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   gl_FragColor = texture2D(uSampler, vTextureCoord);',
-        '   gl_FragColor.r = 1.0 - gl_FragColor.r;',
-        '   gl_FragColor.g = 1.0 - gl_FragColor.g;',
-        '   gl_FragColor.b = 1.0 - gl_FragColor.b;',
-        '}'
-    ];
+    fs.readFileSync(__dirname + '/noise.frag', 'utf8')
+    );
 
 };
 
-PIXI.InvertFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI.InvertFilter.prototype.constructor = PIXI.InvertFilter;
+InvertFilter.prototype = Object.create(core.AbstractFilter.prototype);
+InvertFilter.prototype.constructor = InvertFilter;
 
-
+module.exports = InvertFilter;

--- a/src/NoiseFilter.js
+++ b/src/NoiseFilter.js
@@ -1,97 +1,43 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
-
-PIXI_GLITCH.NoiseFilter = function () {
-    PIXI.AbstractFilter.call(this);
-
-    this.passes = [this];
-
-    this.uniforms = {
-        rand: {type: '1f', value: 0.5},
-        strength: {type: '1f', value: 0.25},
-        dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'uniform vec4 dimensions;',
-        'uniform float rand;',
-        'uniform float strength;',
-        'varying vec2 vTextureCoord;',
-
-        'vec3 mod289(vec3 x) {',
-        '   return x - floor(x * (1.0 / 289.0)) * 289.0;',
-        '}',
-
-        'vec2 mod289(vec2 x) {',
-        '   return x - floor(x * (1.0 / 289.0)) * 289.0;',
-        '}',
-
-        'vec3 permute(vec3 x) {',
-        '   return mod289(((x * 34.0) + 1.0) * x);',
-        '}',
-
-        'float snoise(vec2 v)',
-        '{',
-        '   const vec4 C = vec4(0.211324865405187, 0.366025403784439, -0.577350269189626, 0.024390243902439);',
-        '   vec2 i = floor(v + dot(v, C.yy));',
-        '   vec2 x0 = v - i + dot(i, C.xx);',
-        '   vec2 i1;',
-        '   i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);',
-        '   vec4 x12 = x0.xyxy + C.xxzz;',
-        '   x12.xy -= i1;',
-        '   i = mod289(i);',
-        '   vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0 )) + i.x + vec3(0.0, i1.x, 1.0));',
-        '   vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x12.xy,x12.xy), dot(x12.zw,x12.zw)), 0.0);',
-        '   m = m * m;',
-        '   m = m * m;',
-        '   vec3 x = 2.0 * fract(p * C.www) - 1.0;',
-        '   vec3 h = abs(x) - 0.5;',
-        '   vec3 ox = floor(x + 0.5);',
-        '   vec3 a0 = x - ox;',
-        '   m *= 1.79284291400159 - 0.85373472095314 * ( a0*a0 + h*h );',
-        '   vec3 g;',
-        '   g.x  = a0.x  * x0.x  + h.x  * x0.y;',
-        '   g.yz = a0.yz * x12.xz + h.yz * x12.yw;',
-        '   return 130.0 * dot(m, g);',
-        '}',
-
-        'void main (void)',
-        '{',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec2 posOffset = vec2(pos.x * pos.y + rand * 231.5, pos.x + pos.y - rand * 324.1);',
-        '   col.rgb = col.rgb + snoise(posOffset) * strength;',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
-
-};
-
-PIXI_GLITCH.NoiseFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.NoiseFilter.prototype.constructor = PIXI_GLITCH.NoiseFilter;
-
-Object.defineProperty(PIXI_GLITCH.NoiseFilter.prototype, 'strength', {
-    get: function() {
-        return this.uniforms.strength.value;
-    },
-    set: function(value) {
-        this.dirty = true;
-        this.uniforms.strength.value = value;
+function NoiseFilter() {
+  core.AbstractFilter.call(this,
+    null,
+    fs.readFileSync(__dirname + '/noise.frag', 'utf8')
+    , {
+      rand      : {type: '1f', value: 1.5},
+      strength  : {type: '1f', value: 0.25},
+      dimensions: {type: '4fv', value: [0, 0, 0, 0]}
     }
+  );
+}
+
+NoiseFilter.prototype = Object.create(core.AbstractFilter.prototype);
+NoiseFilter.prototype.constructor = NoiseFilter;
+
+Object.defineProperty(NoiseFilter.prototype, 'strength', {
+  get: function () {
+    return this.uniforms.strength.value;
+  },
+  set: function (value) {
+    this.dirty = true;
+    this.uniforms.strength.value = value;
+  }
 });
 
-Object.defineProperty(PIXI_GLITCH.NoiseFilter.prototype, 'rand', {
-    get: function() {
-        return this.uniforms.rand.value;
-    },
-    set: function(value) {
-        this.dirty = true;
-        this.uniforms.rand.value = value;
-    }
+Object.defineProperty(NoiseFilter.prototype, 'rand', {
+  get: function () {
+    return this.uniforms.rand.value;
+  },
+  set: function (value) {
+    this.dirty = true;
+    this.uniforms.rand.value = value;
+  }
 });
 
+module.exports = NoiseFilter;

--- a/src/OutlineFilter.js
+++ b/src/OutlineFilter.js
@@ -1,49 +1,25 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function OutlineFilter() {
+    PIXI.AbstractFilter.call(this,
+    
+    null,
 
-PIXI_GLITCH.OutlineFilter = function () {
-    PIXI.AbstractFilter.call(this);
+    fs.readFileSync(__dirname + '/outline.frag', 'utf8'),
 
-    this.passes = [this];
-
-    this.uniforms = {
+    {
         dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'uniform vec4 dimensions;',
-        'varying vec2 vTextureCoord;',
-        'const int step = 5;',
-        'void main (void)',
-        '{',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec4 cols[25];',
-        '   for (int i = 0; i < step; i++) {',
-        '       for (int j = 0; j < step; j++) {',
-        '           vec2 coord = vec2((pos.x + float(j) - 1.0), (pos.y + float(i) - 1.0)) / vec2(dimensions);',
-        '           cols[i * step + j] = texture2D(uSampler, coord);',
-        '           cols[i * step + j].r = (cols[i * step + j].r + cols[i * step + j].g + cols[i * step + j].b) / 3.0;',
-        '       }',
-        '   }',
-        '   float mn = 1.0, mx = 0.0;',
-        '   for (int i = 0; i < step * step; i++){',
-        '       mn = min(cols[i].r, mn);',
-        '       mx = max(cols[i].r, mx);',
-        '   }',
-        '   float dst = abs(1.0 - (mx - mn));',
-        '   gl_FragColor.a = 1.0;',
-        '   gl_FragColor.rgb = vec3(dst, dst, dst) + cols[12].rgb;',
-        '}'
-    ];
+    }
+    );
 
 };
 
-PIXI_GLITCH.OutlineFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.OutlineFilter.prototype.constructor = PIXI_GLITCH.OutlineFilter;
+OutlineFilter.prototype = Object.create(core.AbstractFilter.prototype);
+OutlineFilter.prototype.constructor = OutlineFilter;
 
-
+module.exports = OutlineFilter; 

--- a/src/PassThroughFilter.js
+++ b/src/PassThroughFilter.js
@@ -1,28 +1,22 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function PassThroughFilter()
+{
+  core.AbstractFilter.call(this,
+    // vertex shader
+    null,
+    // fragment shader
+    fs.readFileSync(__dirname + '/passthrough.frag', 'utf8')
+  );
+}
 
-PIXI_GLITCH.PassThroughFilter = function () {
-    PIXI.AbstractFilter.call(this);
-
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
-
-};
-
-PIXI_GLITCH.PassThroughFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.PassThroughFilter.prototype.constructor = PIXI_GLITCH.PassThroughFilter;
+PassThroughFilter.prototype = Object.create(core.AbstractFilter.prototype);
+PassThroughFilter.prototype.constructor = PassThroughFilter;
 
 
+module.exports = PassThroughFilter;

--- a/src/RedInvertFilter.js
+++ b/src/RedInvertFilter.js
@@ -1,35 +1,22 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function RedInvertFilter() {
+    core.AbstractFilter.call(this,
+      
+      null,
 
-PIXI_GLITCH.RedInvertFilter = function () {
-    PIXI.AbstractFilter.call(this);
+      fs.readFileSync(__dirname + '/redinvert.frag', 'utf8'));
 
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(0.4,0.2,0.2);',
-        '   vec3 min = vec3(1.0,0.0,0.0);',
-        '   vec3 max = vec3(0.0,1.0,1.0);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
 
 };
 
-PIXI_GLITCH.RedInvertFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.RedInvertFilter.prototype.constructor = PIXI_GLITCH.RedInvertFilter;
+RedInvertFilter.prototype = Object.create(core.AbstractFilter.prototype);
+RedInvertFilter.prototype.constructor = RedInvertFilter;
 
+module.exports = RedInvertFilter;
 

--- a/src/RedRaiseFilter.js
+++ b/src/RedRaiseFilter.js
@@ -1,35 +1,20 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function RedRaiseFilter() {
+    core.AbstractFilter.call(this,
 
-PIXI_GLITCH.RedRaiseFilter = function () {
-    PIXI.AbstractFilter.call(this);
+      null,
 
-    this.passes = [this];
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float e = 2.718281828459045235360287471352;',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   vec3 k =   vec3(.25,0.2,0.2);',
-        '   vec3 min = vec3(0.2,0.0,0.0);',
-        '   vec3 max = vec3(0.8,1.0,1.0);',
-        '   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);',
-        '   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);',
-        '   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
-
+      fs.readFileSync(__dirname + '/redraise.frag', 'utf8')
+    );
 };
 
-PIXI_GLITCH.RedRaiseFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.RedRaiseFilter.prototype.constructor = PIXI_GLITCH.RedRaiseFilter;
+RedRaiseFilter.prototype = Object.create(core.AbstractFilter.prototype);
+RedRaiseFilter.prototype.constructor = RedRaiseFilter;
 
-
+module.exports = RedRaiseFilter;

--- a/src/ShakerFilter.js
+++ b/src/ShakerFilter.js
@@ -2,47 +2,30 @@
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-PIXI_GLITCH.ShakerFilter = function () {
-    PIXI.AbstractFilter.call(this);
+function ShakerFilter() {
+    core.AbstractFilter.call(this,
+      
+      null,
 
-    this.passes = [this];
+      fs.readFileSync(__dirname + '/shaker.frag', 'utf8'),
 
-    this.uniforms = {
+
+    {
         dimensions: {type: '4fv', value: [0, 0, 0, 0]},
         blur: {type: '2fv', value: [5, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'uniform vec2 blur;',
-        'uniform vec4 dimensions;',
-        'void main (void)',
-        '{',
-        '   vec4 col = texture2D(uSampler, vTextureCoord);',
-        '   float pix_w = 1.0 / dimensions.x;',
-        '   float pix_h = 1.0 / dimensions.y;',
-        '   vec4 col_s[5], col_s2[5];',
-        '   for (int i = 0;i < 5;i++){',
-        '       col_s[i] = texture2D(uSampler, vTextureCoord + vec2(-pix_w * float(i) * blur.x, -pix_h * float(i) * blur.y));',
-        '       col_s2[i] = texture2D(uSampler, vTextureCoord + vec2( pix_w * float(i) * blur.x, pix_h * float(i) * blur.y));',
-        '   }',
-        '   col_s[0] = (col_s[0] + col_s[1] + col_s[2] + col_s[3] + col_s[4])/5.0;',
-        '   col_s2[0]= (col_s2[0] + col_s2[1] + col_s2[2] + col_s2[3] + col_s2[4])/5.0;',
-        '   col = (col_s[0] + col_s2[0]) / 2.0;',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+    }
+    );
 
 };
 
-PIXI_GLITCH.ShakerFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.ShakerFilter.prototype.constructor = PIXI_GLITCH.ShakerFilter;
+ShakerFilter.prototype = Object.create(core.AbstractFilter.prototype);
+ShakerFilter.prototype.constructor = ShakerFilter;
 
-Object.defineProperty(PIXI_GLITCH.ShakerFilter.prototype, 'blurX', {
+Object.defineProperty(ShakerFilter.prototype, 'blurX', {
     get: function() {
         return this.uniforms.blur.value[0];
     },
@@ -52,7 +35,7 @@ Object.defineProperty(PIXI_GLITCH.ShakerFilter.prototype, 'blurX', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.ShakerFilter.prototype, 'blurY', {
+Object.defineProperty(ShakerFilter.prototype, 'blurY', {
     get: function() {
         return this.uniforms.blur.value[1];
     },
@@ -61,3 +44,5 @@ Object.defineProperty(PIXI_GLITCH.ShakerFilter.prototype, 'blurY', {
         this.uniforms.blur.value[1] = value;
     }
 });
+
+module.exports = ShakerFilter;

--- a/src/SlitScanFilter.js
+++ b/src/SlitScanFilter.js
@@ -1,41 +1,28 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function SlitScanFilter() {
+    core.AbstractFilter.call(this,
 
-PIXI_GLITCH.SlitScanFilter = function () {
-    PIXI.AbstractFilter.call(this);
+      null,
 
-    this.passes = [this];
+      fs.readFileSync(__dirname + '/slitscan.frag', 'utf8'),
 
-    this.uniforms = {
+  {
         rand: {type: '1f', value: 15},
         dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform float rand;',
-        'uniform vec4 dimensions;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float slit_h = rand;',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec2 texCoord = vec2(3.0+floor(pos.x/slit_h)*slit_h ,pos.y);',
-        '   vec4 col = texture2D(uSampler, texCoord / vec2(dimensions));',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+    });
 
 };
 
-PIXI_GLITCH.SlitScanFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.SlitScanFilter.prototype.constructor = PIXI_GLITCH.SlitScanFilter;
+SlitScanFilter.prototype = Object.create(core.AbstractFilter.prototype);
+SlitScanFilter.prototype.constructor = SlitScanFilter;
 
-Object.defineProperty(PIXI_GLITCH.SlitScanFilter.prototype, 'rand', {
+Object.defineProperty(SlitScanFilter.prototype, 'rand', {
     get: function() {
         return this.uniforms.rand.value;
     },
@@ -44,5 +31,7 @@ Object.defineProperty(PIXI_GLITCH.SlitScanFilter.prototype, 'rand', {
         this.uniforms.rand.value = value;
     }
 });
+
+module.exports = SlitScanFilter;
 
 

--- a/src/SwellFilter.js
+++ b/src/SwellFilter.js
@@ -1,42 +1,29 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function SwellFilter() {
+    PIXI.AbstractFilter.call(this,
+      
+      null,
 
-PIXI_GLITCH.SwellFilter = function () {
-    PIXI.AbstractFilter.call(this);
+      fs.readFileSync(__dirname + '/swell.frag', 'utf8'),
 
-    this.passes = [this];
-
-    this.uniforms = {
+  {
         rand: {type: '1f', value: 0.5},
         timer: {type: '1f', value: 0},
         dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
-
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform float rand;',
-        'uniform float timer;',
-        'uniform vec4 dimensions;',
-        'uniform sampler2D uSampler;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec2 sampleFrom = (pos + vec2(sin(pos.y * 0.03 + timer * 20.0) * (6.0 + 12.0 * rand), 0)) / vec2(dimensions);',
-        '   vec4 col_s = texture2D(uSampler, sampleFrom);',
-        '   gl_FragColor.rgba = col_s.rgba;',
-        '}'
-    ];
-
+    }
+    );
 };
 
-PIXI_GLITCH.SwellFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.SwellFilter.prototype.constructor = PIXI_GLITCH.SwellFilter;
+SwellFilter.prototype = Object.create(core.AbstractFilter.prototype);
+SwellFilter.prototype.constructor = SwellFilter;
 
-Object.defineProperty(PIXI_GLITCH.SwellFilter.prototype, 'rand', {
+Object.defineProperty(SwellFilter.prototype, 'rand', {
     get: function() {
         return this.uniforms.rand.value;
     },
@@ -46,7 +33,7 @@ Object.defineProperty(PIXI_GLITCH.SwellFilter.prototype, 'rand', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.SwellFilter.prototype, 'timer', {
+Object.defineProperty(SwellFilter.prototype, 'timer', {
     get: function() {
         return this.uniforms.timer.value;
     },
@@ -55,4 +42,6 @@ Object.defineProperty(PIXI_GLITCH.SwellFilter.prototype, 'timer', {
         this.uniforms.timer.value = value;
     }
 });
+
+module.exports = SwellFilter;
 

--- a/src/TwistFilter.js
+++ b/src/TwistFilter.js
@@ -1,48 +1,32 @@
 /**
  * @author Matt Smith http://gun.net.au @ktingvoar
  */
+var core = require('../../node_modules/pixi.js/src/core');
+// @see https://github.com/substack/brfs/issues/25
+var fs = require('fs');
 
-var PIXI_GLITCH = PIXI_GLITCH || {};
+function TwistFilter() {
+    core.AbstractFilter.call(this,
+  
+    null,
 
-PIXI_GLITCH.TwistFilter = function () {
-    PIXI.AbstractFilter.call(this);
-
-    this.passes = [this];
-
-    this.uniforms = {
+    fs.readFileSync(__dirname + '/twist.frag', 'utf8'),
+      
+  {
         rand: {type: '1f', value: 0.5},
         timer: {type: '1f', value: 0},
         val2: {type: '1f', value: 5},
         val3: {type: '1f', value: 55},
         dimensions: {type: '4fv', value: [0, 0, 0, 0]}
-    };
+    }
+  );
 
-    this.fragmentSrc = [
-        'precision mediump float;',
-        'uniform sampler2D uSampler;',
-        'uniform float rand;',
-        'uniform float timer;',
-        'uniform float val2;',
-        'uniform float val3;',
-        'uniform vec4 dimensions;',
-        'varying vec2 vTextureCoord;',
-        'void main (void)',
-        '{',
-        '   float trueWidth = dimensions.x;',
-        '   float trueHeight = dimensions.y;',
-        '   vec2 pos = vTextureCoord * vec2(dimensions);',
-        '   vec2 texCoord = vec2(max(3.0, min(float(trueWidth), pos.x + sin(pos.y / (153.25 * rand * rand) * rand + rand * val2 + timer * 3.0) * val3)), max(3.0, min(float(trueHeight), pos.y + cos(pos.x/(251.57 * rand * rand) * rand + rand * val2 + timer * 2.4) * val3)- 3.0));',
-        '   vec4 col = texture2D(uSampler, texCoord / vec2(dimensions));',
-        '   gl_FragColor.rgba = col.rgba;',
-        '}'
-    ];
+}
 
-};
+TwistFilter.prototype = Object.create(core.AbstractFilter.prototype);
+TwistFilter.prototype.constructor = TwistFilter;
 
-PIXI_GLITCH.TwistFilter.prototype = Object.create(PIXI.AbstractFilter.prototype);
-PIXI_GLITCH.TwistFilter.prototype.constructor = PIXI_GLITCH.TwistFilter;
-
-Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'rand', {
+Object.defineProperty(TwistFilter.prototype, 'rand', {
     get: function() {
         return this.uniforms.rand.value;
     },
@@ -52,7 +36,7 @@ Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'rand', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'timer', {
+Object.defineProperty(TwistFilter.prototype, 'timer', {
     get: function() {
         return this.uniforms.timer.value;
     },
@@ -62,7 +46,7 @@ Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'timer', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'val2', {
+Object.defineProperty(TwistFilter.prototype, 'val2', {
     get: function() {
         return this.uniforms.val2.value;
     },
@@ -72,7 +56,7 @@ Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'val2', {
     }
 });
 
-Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'val3', {
+Object.defineProperty(TwistFilter.prototype, 'val3', {
     get: function() {
         return this.uniforms.val3.value;
     },
@@ -82,3 +66,4 @@ Object.defineProperty(PIXI_GLITCH.TwistFilter.prototype, 'val3', {
     }
 });
 
+module.exports = TwistFilter;

--- a/src/blueinvert.frag
+++ b/src/blueinvert.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(0.2,0.2,0.4);
+   vec3 min = vec3(0.0,0.0,1.0);
+   vec3 max = vec3(1.0,1.0,0.0);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/blueraise.frag
+++ b/src/blueraise.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(0.2,0.2,.25);
+   vec3 min = vec3(0.0,0.0,0.2);
+   vec3 max = vec3(1.0,1.0,0.8);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/convergence.frag
+++ b/src/convergence.frag
@@ -1,0 +1,16 @@
+precision mediump float;
+uniform float rand;
+uniform vec4 dimensions;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec4 col_r = texture2D(uSampler, vTextureCoord + vec2((-35.0 / dimensions.x) * rand, 0));
+   vec4 col_l = texture2D(uSampler, vTextureCoord + vec2((35.0 / dimensions.x) * rand, 0));
+   vec4 col_g = texture2D(uSampler, vTextureCoord + vec2((-7.5 / dimensions.x) * rand, 0));
+   col.r = col.r + col_l.r * max(1.0, sin(vTextureCoord.y * dimensions.y * 1.2) * 2.5) * rand;
+   col.b = col.b + col_r.b * max(1.0, sin(vTextureCoord.y * dimensions.y * 1.2) * 2.5) * rand;
+   col.g = col.g + col_g.g * max(1.0, sin(vTextureCoord.y * dimensions.y * 1.2) * 2.5) * rand;
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/cutslider.frag
+++ b/src/cutslider.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+uniform float rand;
+uniform float val1;
+uniform float val2;
+uniform vec4 dimensions;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   vec2 pos = vTextureCoord * vec2(dimensions);
+   vec2 posOffset = pos + vec2(floor(sin(pos.y / val1 * rand + rand * rand)) * val2 * rand, 0);
+   posOffset = posOffset / vec2(dimensions);
+   vec4 col = texture2D(uSampler, posOffset);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/glow.frag
+++ b/src/glow.frag
@@ -1,0 +1,27 @@
+precision mediump float;
+uniform vec4 dimensions;
+uniform sampler2D uSampler;
+uniform int blur_w;
+varying vec2 vTextureCoord;
+const float strength = 1.3;
+void main (void)
+{
+   vec2 pos = vTextureCoord * vec2(dimensions);
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec4 gws = vec4(0.0, 0.0, 0.0, 1.0);
+   float weight = 1.0 / (float(blur_w) * 2.0 + 1.0) / (float(blur_w) * 2.0 + 1.0);
+   for (int i = 0; i < 1024; i++) {
+       if (i > blur_w * blur_w) {break;}
+       float miw = float(mod(float(i), float(blur_w)));
+       float idw = float(i / blur_w);
+       vec2 v1 = vec2(pos.x + miw, pos.y + idw);
+       vec2 v2 = vec2(pos.x - miw, pos.y + idw);
+       vec2 v3 = vec2(pos.x + miw, pos.y - idw);
+       vec2 v4 = vec2(pos.x - miw, pos.y - idw);
+       gws = gws + texture2D(uSampler, v1 / vec2(dimensions)) * weight * strength;
+       gws = gws + texture2D(uSampler, v2 / vec2(dimensions)) * weight * strength;
+       gws = gws + texture2D(uSampler, v3 / vec2(dimensions)) * weight * strength;
+       gws = gws + texture2D(uSampler, v4 / vec2(dimensions)) * weight * strength;
+   }
+   gl_FragColor.rgba = col + gws;
+}

--- a/src/greeninvert.frag
+++ b/src/greeninvert.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(0.2,0.4,0.2);
+   vec3 min = vec3(0.0,1.0,0.0);
+   vec3 max = vec3(1.0,0.8,1.0);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/greenraise.frag
+++ b/src/greenraise.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(0.2,.25,0.2);
+   vec3 min = vec3(0.0,0.2,0.0);
+   vec3 max = vec3(1.0,0.8,1.0);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/highcontrast.frag
+++ b/src/highcontrast.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(0.8,0.8,0.8);
+   vec3 min = vec3(0.0,0.0,0.0);
+   vec3 max = vec3(1.0,1.0,1.0);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/invert.frag
+++ b/src/invert.frag
@@ -1,0 +1,11 @@
+precision mediump float;
+uniform sampler2D uSampler;
+uniform bool enabled;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   gl_FragColor = texture2D(uSampler, vTextureCoord);
+   gl_FragColor.r = 1.0 - gl_FragColor.r;
+   gl_FragColor.g = 1.0 - gl_FragColor.g;
+   gl_FragColor.b = 1.0 - gl_FragColor.b;
+}

--- a/src/noise.frag
+++ b/src/noise.frag
@@ -1,0 +1,52 @@
+precision mediump float;
+uniform sampler2D uSampler;
+uniform vec4 dimensions;
+        uniform float rand;
+        uniform float strength;
+        varying vec2 vTextureCoord;
+
+        vec3 mod289(vec3 x) {
+           return x - floor(x * (1.0 / 289.0)) * 289.0;
+        }
+
+        vec2 mod289(vec2 x) {
+           return x - floor(x * (1.0 / 289.0)) * 289.0;
+        }
+
+        vec3 permute(vec3 x) {
+           return mod289(((x * 34.0) + 1.0) * x);
+        }
+
+        float snoise(vec2 v)
+        {
+           const vec4 C = vec4(0.211324865405187, 0.366025403784439, -0.577350269189626, 0.024390243902439);
+           vec2 i = floor(v + dot(v, C.yy));
+           vec2 x0 = v - i + dot(i, C.xx);
+           vec2 i1;
+           i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+           vec4 x12 = x0.xyxy + C.xxzz;
+           x12.xy -= i1;
+           i = mod289(i);
+           vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0 )) + i.x + vec3(0.0, i1.x, 1.0));
+           vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x12.xy,x12.xy), dot(x12.zw,x12.zw)), 0.0);
+           m = m * m;
+           m = m * m;
+           vec3 x = 2.0 * fract(p * C.www) - 1.0;
+           vec3 h = abs(x) - 0.5;
+           vec3 ox = floor(x + 0.5);
+           vec3 a0 = x - ox;
+           m *= 1.79284291400159 - 0.85373472095314 * ( a0*a0 + h*h );
+           vec3 g;
+           g.x  = a0.x  * x0.x  + h.x  * x0.y;
+           g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+           return 130.0 * dot(m, g);
+        }
+
+        void main (void)
+        {
+           vec4 col = texture2D(uSampler, vTextureCoord);
+           vec2 pos = vTextureCoord * vec2(dimensions);
+           vec2 posOffset = vec2(pos.x * pos.y + rand * 231.5, pos.x + pos.y - rand * 324.1);
+           col.rgb = col.rgb + snoise(posOffset) * strength;
+           gl_FragColor.rgba = col.rgba;
+        }

--- a/src/outline.frag
+++ b/src/outline.frag
@@ -1,0 +1,25 @@
+precision mediump float;
+uniform sampler2D uSampler;
+uniform vec4 dimensions;
+varying vec2 vTextureCoord;
+const int step = 5;
+void main (void)
+{
+   vec2 pos = vTextureCoord * vec2(dimensions);
+   vec4 cols[25];
+   for (int i = 0; i < step; i++) {
+       for (int j = 0; j < step; j++) {
+           vec2 coord = vec2((pos.x + float(j) - 1.0), (pos.y + float(i) - 1.0)) / vec2(dimensions);
+           cols[i * step + j] = texture2D(uSampler, coord);
+           cols[i * step + j].r = (cols[i * step + j].r + cols[i * step + j].g + cols[i * step + j].b) / 3.0;
+       }
+   }
+   float mn = 1.0, mx = 0.0;
+   for (int i = 0; i < step * step; i++){
+       mn = min(cols[i].r, mn);
+       mx = max(cols[i].r, mx);
+   }
+   float dst = abs(1.0 - (mx - mn));
+   gl_FragColor.a = 1.0;
+   gl_FragColor.rgb = vec3(dst, dst, dst) + cols[12].rgb;
+}

--- a/src/passthrough.frag
+++ b/src/passthrough.frag
@@ -1,0 +1,7 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void){
+  vec4 col = texture2D(uSampler, vTextureCoord);
+  gl_FragColor.rgba = col.rgba;
+}

--- a/src/redinvert.frag
+++ b/src/redinvert.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(0.4,0.2,0.2);
+   vec3 min = vec3(1.0,0.0,0.0);
+   vec3 max = vec3(0.0,1.0,1.0);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/redraise.frag
+++ b/src/redraise.frag
@@ -1,0 +1,15 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float e = 2.718281828459045235360287471352;
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   vec3 k =   vec3(.25,0.2,0.2);
+   vec3 min = vec3(0.2,0.0,0.0);
+   vec3 max = vec3(0.8,1.0,1.0);
+   col.r = (1.0/(1.0+pow(e,(-k.r*((col.r*2.0)-1.0)*20.0)))*(max.r-min.r)+min.r);
+   col.g = (1.0/(1.0+pow(e,(-k.g*((col.g*2.0)-1.0)*20.0)))*(max.g-min.g)+min.g);
+   col.b = (1.0/(1.0+pow(e,(-k.b*((col.b*2.0)-1.0)*20.0)))*(max.b-min.b)+min.b);
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/shaker.frag
+++ b/src/shaker.frag
@@ -1,0 +1,20 @@
+precision mediump float;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+uniform vec2 blur;
+uniform vec4 dimensions;
+void main (void)
+{
+   vec4 col = texture2D(uSampler, vTextureCoord);
+   float pix_w = 1.0 / dimensions.x;
+   float pix_h = 1.0 / dimensions.y;
+   vec4 col_s[5], col_s2[5];
+   for (int i = 0;i < 5;i++){
+       col_s[i] = texture2D(uSampler, vTextureCoord + vec2(-pix_w * float(i) * blur.x, -pix_h * float(i) * blur.y));
+       col_s2[i] = texture2D(uSampler, vTextureCoord + vec2( pix_w * float(i) * blur.x, pix_h * float(i) * blur.y));
+   }
+   col_s[0] = (col_s[0] + col_s[1] + col_s[2] + col_s[3] + col_s[4])/5.0;
+   col_s2[0]= (col_s2[0] + col_s2[1] + col_s2[2] + col_s2[3] + col_s2[4])/5.0;
+   col = (col_s[0] + col_s2[0]) / 2.0;
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/slitscan.frag
+++ b/src/slitscan.frag
@@ -1,0 +1,13 @@
+precision mediump float;
+uniform float rand;
+uniform vec4 dimensions;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float slit_h = rand;
+   vec2 pos = vTextureCoord * vec2(dimensions);
+   vec2 texCoord = vec2(3.0+floor(pos.x/slit_h)*slit_h ,pos.y);
+   vec4 col = texture2D(uSampler, texCoord / vec2(dimensions));
+   gl_FragColor.rgba = col.rgba;
+}

--- a/src/swell.frag
+++ b/src/swell.frag
@@ -1,0 +1,13 @@
+precision mediump float;
+uniform float rand;
+uniform float timer;
+uniform vec4 dimensions;
+uniform sampler2D uSampler;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   vec2 pos = vTextureCoord * vec2(dimensions);
+   vec2 sampleFrom = (pos + vec2(sin(pos.y * 0.03 + timer * 20.0) * (6.0 + 12.0 * rand), 0)) / vec2(dimensions);
+   vec4 col_s = texture2D(uSampler, sampleFrom);
+   gl_FragColor.rgba = col_s.rgba;
+}

--- a/src/twist.frag
+++ b/src/twist.frag
@@ -1,0 +1,17 @@
+precision mediump float;
+uniform sampler2D uSampler;
+uniform float rand;
+uniform float timer;
+uniform float val2;
+uniform float val3;
+uniform vec4 dimensions;
+varying vec2 vTextureCoord;
+void main (void)
+{
+   float trueWidth = dimensions.x;
+   float trueHeight = dimensions.y;
+   vec2 pos = vTextureCoord * vec2(dimensions);
+   vec2 texCoord = vec2(max(3.0, min(float(trueWidth), pos.x + sin(pos.y / (153.25 * rand * rand) * rand + rand * val2 + timer * 3.0) * val3)), max(3.0, min(float(trueHeight), pos.y + cos(pos.x/(251.57 * rand * rand) * rand + rand * val2 + timer * 2.4) * val3)- 3.0));
+   vec4 col = texture2D(uSampler, texCoord / vec2(dimensions));
+   gl_FragColor.rgba = col.rgba;
+}


### PR DESCRIPTION
Removed the global namespace PIXI_GLITCH in favour of module import/export for es6. 

More importantly changed the filter object structures so they are compatible with PIXI v3.
